### PR TITLE
test: increase visual regression thresholds for UI tests

### DIFF
--- a/tests/gitops/test_pull_request_environment.py
+++ b/tests/gitops/test_pull_request_environment.py
@@ -607,7 +607,7 @@ ingress:
                 grafana_page, comment_data['grafana_metrics_url'],
                 description="Grafana Metrics Dashboard",
                 baseline_key="pr_grafana_metrics_dashboard",
-                threshold=1.0
+                threshold=2.0
             )
             logger.info(f"   ✓ Grafana metrics screenshot captured")
             

--- a/tests/ui/test_grafana_dashboard.py
+++ b/tests/ui/test_grafana_dashboard.py
@@ -59,7 +59,7 @@ def test_grafana_dashboard(authenticated_grafana_page, captain_domain, screensho
         page, page.url,
         description="Kubernetes Compute Resources Dashboard",
         baseline_key="grafana_k8s_compute_dashboard",
-        threshold=2.0
+        threshold=10.0
     )
     
     # Assert no visual regressions

--- a/tests/ui/test_oauth_redirect_to_github.py
+++ b/tests/ui/test_oauth_redirect_to_github.py
@@ -63,7 +63,7 @@ def test_oauth_redirect_to_github(page, captain_domain, screenshots, service_nam
         page, final_url,
         description=f"{service_name} - GitHub OAuth Login",
         baseline_key=f"github_oauth_{service_name}",
-        threshold=0.0
+        threshold=1.0
     )
     
     # Assert no visual regressions

--- a/tests/ui/test_vault_secrets.py
+++ b/tests/ui/test_vault_secrets.py
@@ -78,7 +78,7 @@ def test_vault_secrets(vault_test_secrets, authenticated_vault_page, captain_dom
         page, page.url,
         description="Vault Secrets List",
         baseline_key="vault_secrets_list",
-        threshold=0.5
+        threshold=2.0
     )
     
     # Assert no visual regressions


### PR DESCRIPTION
Adjust screenshot comparison thresholds to reduce false positives:
- test_grafana_dashboard: 2.0 → 10.0 (dashboard content varies)
- test_oauth_redirect_to_github: 0.0 → 1.0 (minor rendering differences)
- test_vault_secrets: 0.5 → 2.0 (content updates expected)
- test_pull_request_environment: 1.0 → 2.0 (Grafana metrics dashboard)

These changes account for acceptable visual variations in dynamic content like metrics dashboards and UI elements while maintaining regression detection for significant changes.